### PR TITLE
fancy quote cog with most work incorporated from previous clembot commits

### DIFF
--- a/bot/cogs/Fancy_Quote.py
+++ b/bot/cogs/Fancy_Quote.py
@@ -1,0 +1,56 @@
+import logging
+import discord
+import discord.ext.commands as commands
+import bot.extensions as ext
+from bot.consts import Colors
+
+log = logging.getLogger(__name__)
+
+
+class FancyQuoteCog(commands.Cog):
+    def __init__(self, bot) -> None:
+        self.bot = bot
+        self._last_member: discord.Member | None = None
+
+    @ext.command()
+    @ext.long_help(
+        "Creates a fancy quote based on the given message with the author either being given or being the username")
+    @ext.short_help("Creates a fancy quote from the given value")
+    @ext.example("fancy_quote \"<Author Name>\" <Quote String>")
+    async def fancy_quote(self, ctx, member: discord.Member | str, *, quote: str) -> None:
+
+        error_title = ""
+        error_message = ""
+
+        if member is None:
+            error_title = "Missing member argument"
+            error_message = f"Invalid argument(s): Missing member value. See `{await self.bot.current_prefix(ctx)}help fancy_quote` for info."
+        elif quote is None:
+            error_title = "Missing quote argument"
+            error_message = f"Invalid argument(s): Missing quote value. See `{await self.bot.current_prefix(ctx)}help fancy_quote` for info."
+        if error_title != "":
+            embed = discord.Embed(title="Fancy_Quote", color=Colors.Error)
+            embed.add_field(name="ERROR: " + error_title, value=error_message, inline=False)
+            await ctx.send(embed=embed)
+            return
+
+        embed = discord.Embed(
+            title="",
+            color=Colors.Purple,
+        )
+        embed.add_field(
+            name="",
+            value=f"\"*{quote}*\"",
+            inline=False,
+        )
+        embed.set_footer(text=str(ctx.author), icon_url=ctx.author.display_avatar.url)
+        if isinstance(member, discord.Member):
+            embed.title = f"{member.nick}"
+            embed.set_thumbnail(url=member.display_avatar.url)
+        else:
+            embed.title = member
+        await ctx.send(embed=embed)
+
+
+async def setup(bot) -> None:
+    await bot.add_cog(FancyQuoteCog(bot))

--- a/bot/cogs/Fancy_Quote.py
+++ b/bot/cogs/Fancy_Quote.py
@@ -16,7 +16,12 @@ class FancyQuoteCog(commands.Cog):
     @ext.long_help(
         "Creates a fancy quote based on the given message with the author either being given or being the username")
     @ext.short_help("Creates a fancy quote from the given value")
-    @ext.example("fancy_quote \"<Author Name>\" <Quote String>")
+    @ext.example(
+        (
+                "fancy_quote @<Author Name> <Quote String>",
+                "fancy_quote <Author Name> <Quote String>"
+        )
+    )
     async def fancy_quote(self, ctx, member: discord.Member | str, *, quote: str) -> None:
 
         error_title = ""


### PR DESCRIPTION
<img width="315" alt="Screen Shot 2023-12-09 at 5 53 05 PM" src="https://github.com/Jay-Madden/SockBot/assets/75497722/df63b450-6327-49d4-9ec3-682ceb3587c2">
<img width="315" alt="Screen Shot 2023-12-09 at 5 57 28 PM" src="https://github.com/Jay-Madden/SockBot/assets/75497722/a6433c57-0bc1-4eae-b5b8-337d363e0250">

Added functionality for a fancy quote. 

Can be done either by "@ user" or by typing a name string.

If the user is provided by using "@ user" their profile picture is added as an image